### PR TITLE
feature: add devcontainer use sember versioning setting

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,6 +32,14 @@
       "matchPackagePrefixes": [
         "@pothos/"
       ]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchFileNames": [
+        "^.devcontainer/devcontainer.json$",
+        "^.devcontainer.json$"
+      ],
+      "versioning": "semver"
     }
   ]
 }


### PR DESCRIPTION
# Summary

I changed json files under devcontainer to use version tag instead of hash value for docker image.

# Why

Renovate tries to update the base image of devcontainer with a hash, but VSCode (or devcontainer?) doesn't seem to support names with hashes and crashes, so I want to ignore it.

# Check

I have validated the updated file as follows and confirmed that no error occurs.

```bash
$ npx --yes --package renovate -- renovate-config-validator default.json
(node:53509) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating default.json
 INFO: Config validated successfully
```